### PR TITLE
Dg 11 include git hub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -12,6 +12,14 @@ body:
       options:
       - label: I have searched the existing issues
         required: true
+  - type: input
+    id: jiraissue
+    attributes:
+      label: Jira Issue
+      description: If there is already a open issue in Jira, please enter the issue's ID surrounded in Brackets [], otherwise leave empty.
+      placeholder: "ex. [DG-42]"
+    validations:
+      required: false
   - type: markdown
     attributes:
       value: |
@@ -41,11 +49,3 @@ body:
       placeholder: ex. https://dev.azure.com/mauwiidev/django_gh/_build/results?buildId=1337&view=results
     validations:
       required: true
-  - type: input
-    id: jiraissue
-    attributes:
-      label: Jira Issue
-      description: If there is already a open issue in Jira, please enter the issue's ID surrounded in Brackets [], otherwise leave empty.
-      placeholder: "ex. [DG-42]"
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees:
+  - mauwii
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: input
+    id: failedrun
+    attributes:
+      label: Link to a failed run of the pipeline
+      description: Please open a failed pipeline run, copy the URL and paste it here.
+      placeholder: ex. https://dev.azure.com/mauwiidev/django_gh/_build/results?buildId=1337&view=results
+    validations:
+      required: true
+  - type: input
+    id: jiraissue
+    attributes:
+      label: Jira Issue
+      description: If there is already a open issue in Jira, please enter the issue's ID surrounded in Brackets [], otherwise leave empty.
+      placeholder: "ex. [DG-42]"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Azure Support
+    url: https://portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/overview
+    about: For Problems with Azure Resources

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--
+Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a Jira Issue) and what changes you've made, we can triage your pull request to the best possible team for review.
+-->
+
+### Why:
+
+Closes [Jira ID]
+
+<!--
+- If there's an existing Jira issue for your change, please put it's ID between brackets [like this].
+- If there's _not_ an existing Jira issue, nor a issue here on Github, please open one first to make it more likely that this update will be accepted: https://github.com/mauwii/django_devops/issues/new/choose. -->
+
+### What's being changed:
+
+<!-- Please briefly describe what you have changed and whats the benefit of this change -->


### PR DESCRIPTION
### Why:

Closes [DG-11]

### What's being changed:

- Added a Template-Form for opening a Issue on GitHub
- Added a Pull-Request-Template

[DG-11]: https://mauwii.atlassian.net/browse/DG-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ