### PR TITLE
updated mkdocs-material submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "mkdocs-material"]
 	path = mkdocs-material
 	url = https://github.com/Mauwii/mkdocs-material.git
+	branch = master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ trigger:
     - main
   paths:
     include:
-    - django-webapp
+    - django_webapp
     - pipelines
     - azure-pipelines.yml
 


### PR DESCRIPTION
using my fork instead of the upstream
also fixed include path in azure-pipelines

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a Jira Issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Submodule pointing to upstream instead of my fork

<!--
- If there's an existing Jira issue for your change, please put it's ID between brackets [like this].
- If there's _not_ an existing Jira issue, nor a issue here on Github, please open one first to make it more likely that this update will be accepted: https://github.com/mauwii/django_devops/issues/new/choose. -->

### What's being changed:

- updated url in gitmodules, also pointing to master branch
- fixed include path to django_webapp in azure-pipelines.yml 
<!-- Please briefly describe what you have changed and whats the benefit of this change -->
